### PR TITLE
[bug] fixed a bug, when the source has too many columns.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,8 +89,14 @@ class File {
     if (knownTabularFormats.indexOf(this.descriptor.format) === -1) {
       throw new Error('File is not in known tabular format.')
     }
-    const stream = await this.stream()
-    this.descriptor.schema = await infer(stream)
+    // const stream = await this.stream()
+    // this.descriptor.schema = await infer(stream)
+
+    // tableschema.infer() works better when you pass a PATH or a URL as an argument
+    // it will work with stream as well, but then convert to stream happens twice:
+    // here and in the tableschema lib. As a result some data processing will fail,
+    // without any error e.g. when count(headers) > 1024
+    this.descriptor.schema = await infer(this.path)
   }
 }
 


### PR DESCRIPTION
#issues: 
https://github.com/datahq/data-cli/issues/255 
https://github.com/datahq/datahub-qa/issues/62

### PR is not ready to merge! It is for discussing 
* `data push 1GB.csv` is still failing,
```
data push Big_1800mb.csv
> Error! Array buffer allocation failed
```
I will work with that at monday  


* `data push 1030_columns.csv` is fixed and working!

@anuveyatsu question for you:
I still need to add the tests, that covers this issue with local and remote files
1030_columns test file is 168kb, not too small, but ok.
But how to test program with 1Gb file sample ???  `/dev/random | data push` ? :smile: 