### PR TITLE
Refactored 'parseDatasetIdentifier' function to handle datahub owners that have different user id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -239,7 +239,7 @@ const parsePath = (path_, basePath = null, format = null) => {
   return descriptor
 }
 
-const parseDatasetIdentifier = path_ => {
+const parseDatasetIdentifier = async (path_) => {
   const out = {
     name: '',
     owner: null,
@@ -293,6 +293,11 @@ const parseDatasetIdentifier = path_ => {
       urlparts.host = 'pkgstore.datahub.io'
       owner = parts[1]
       name = parts[2]
+      if (owner !== 'core') {
+        let resolvedPath = await fetch(`https://api.datahub.io/resolver/resolve?path=${owner}/${name}`)
+        resolvedPath = await resolvedPath.json()
+        parts[1] = resolvedPath.userid
+      }
       parts.push('latest')
       urlparts.pathname = parts.join('/')
       out.version = 'latest'
@@ -361,7 +366,7 @@ class Dataset {
     } else { // pathOrDescriptor is a path
       descriptor = {}
       // TODO: owner if provided should override anything parsed from path
-      identifier = parseDatasetIdentifier(pathOrDescriptor)
+      identifier = await parseDatasetIdentifier(pathOrDescriptor)
     }
 
     const dataset = new Dataset(descriptor, identifier)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data.js",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,9 +63,9 @@ test('isDataset function works', t => {
 // ====================================
 // parseDatasetIdentifier
 
-test('parseDatasetIdentifier function with local path', t => {
+test('parseDatasetIdentifier function with local path', async t => {
   const path_ = '../dir/dataset/'
-  const res = data.parseDatasetIdentifier(path_)
+  const res = await data.parseDatasetIdentifier(path_)
   const exp = {
     name: 'dataset',
     owner: null,
@@ -77,9 +77,9 @@ test('parseDatasetIdentifier function with local path', t => {
   t.deepEqual(res, exp)
 })
 
-test('parseDatasetIdentifier function with random url', t => {
+test('parseDatasetIdentifier function with random url', async t => {
   const url_ = 'https://example.com/datasets/co2-ppm/'
-  const res = data.parseDatasetIdentifier(url_)
+  const res = await data.parseDatasetIdentifier(url_)
   const exp = {
     name: 'co2-ppm',
     owner: null,
@@ -91,9 +91,9 @@ test('parseDatasetIdentifier function with random url', t => {
   t.deepEqual(res, exp)
 })
 
-test('parseDatasetIdentifier function with github url', t => {
+test('parseDatasetIdentifier function with github url', async t => {
   const url_ = 'https://github.com/datasets/co2-ppm'
-  const res = data.parseDatasetIdentifier(url_)
+  const res = await data.parseDatasetIdentifier(url_)
   const exp = {
     name: 'co2-ppm',
     owner: 'datasets',
@@ -105,13 +105,31 @@ test('parseDatasetIdentifier function with github url', t => {
   t.deepEqual(res, exp)
 })
 
-test('parseDatasetIdentifier function with datahub url', t => {
+test('parseDatasetIdentifier function with datahub url', async t => {
   const url_ = 'https://datahub.io/core/co2-ppm'
-  const res = data.parseDatasetIdentifier(url_)
+  const res = await data.parseDatasetIdentifier(url_)
   const exp = {
     name: 'co2-ppm',
     owner: 'core',
     path: 'https://pkgstore.datahub.io/core/co2-ppm/latest/',
+    type: 'datahub',
+    original: url_,
+    version: 'latest'
+  }
+  t.deepEqual(res, exp)
+})
+
+test('parseDatasetIdentifier function with datahub url and id different from username', async t => {
+  nock('https://api.datahub.io')
+    .persist()
+    .get('/resolver/resolve?path=username/dataset')
+    .reply(200, {packageid: 'dataset', userid: 'userid'})
+  const url_ = 'https://datahub.io/username/dataset'
+  const res = await data.parseDatasetIdentifier(url_)
+  const exp = {
+    name: 'dataset',
+    owner: 'username',
+    path: 'https://pkgstore.datahub.io/userid/dataset/latest/',
     type: 'datahub',
     original: url_,
     version: 'latest'


### PR DESCRIPTION
This was causing incorrect 'pkgstore' path construction before. - refs https://github.com/datahq/data-cli/issues/266

- includes tests
- commiting as a new version of the package: v0.10.7