### PR TITLE
[File][m] process non-utf8 encoding files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,8 +76,10 @@ class File {
       // and then 'stream-to-array' lib will return strings instead of Buffer objects.
       // Let's transform such strings, otherwise `Buffer.concat` will cause an exception
       return Buffer.concat(buffers.map(buffer => {
-        if (typeof buffer === 'string'){return Buffer(buffer)}
-        else {return buffer}
+        if (typeof buffer === 'string'){
+          return Buffer(buffer)
+        }
+        return buffer
       }))
     })()
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,10 @@ const path = require('path')
 const stream = require('stream')
 const url = require('url')
 
+// encoding helpers
+const iconv = require('iconv-lite')
 const chardet = require('chardet')
+
 const fetch = require('node-fetch')
 const lodash = require('lodash')
 const mime = require('mime-types')
@@ -69,7 +72,13 @@ class File {
     return (async () => {
       const stream = await this.stream()
       const buffers = await toArray(stream)
-      return Buffer.concat(buffers)
+      // Iconv lib that is used for decoding non-utf-8, will return non-standard stream
+      // and then 'stream-to-array' lib will return strings instead of Buffer objects.
+      // Let's transform such strings, otherwise `Buffer.concat` will cause an exception
+      return Buffer.concat(buffers.map(buffer => {
+        if (typeof buffer === 'string'){return Buffer(buffer)}
+        else {return buffer}
+      }))
     })()
   }
 
@@ -109,7 +118,19 @@ class FileLocal extends File {
   }
 
   stream() {
+    // utf-8 and xls(x) files are streamed as usual file reading stream
+    if (this.encoding === DEFAULT_ENCODING || this.path.toLowerCase().includes('xls')) {
+      return fs.createReadStream(this.path)
+    }
+
+    /** WARNING!! Some libs that await standard stream object could not work with iconvStreamObject.
+     * I have fixed it in File class, but other libs, relying on this method, may not work :(
+     * But anyway this could happen only with non-utf8 files, which are broken without this fix.
+     */
+
+    // non utf-8 files are decoded by iconv-lite module
     return fs.createReadStream(this.path)
+      .pipe(iconv.decodeStream(this.encoding))
   }
 
   get size() {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chardet": "^0.1.0",
     "csv-parse": "^1.2.1",
     "csv-sniffer": "^0.1.1",
+    "iconv-lite": "^0.4.19",
     "lodash": "^4.17.4",
     "mime-types": "^2.1.16",
     "node-fetch": "^1.7.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -214,7 +214,7 @@ const testFileStream = async (t, file) => {
   t.deepEqual(rowsAsObjects[1], {number: '3', string: 'four', boolean: 'false'})
 }
 
-test.skip('non utf-8 encoding', async t => {
+test('non utf-8 encoding', async t => {
   const path_ = 'test/fixtures/sample-cyrillic-encoding.csv'
   const file = await data.File.load(path_)
   const buffer = await file.buffer


### PR DESCRIPTION
This changes allows  `FileLocal` class to decode non-utf8 files into stream, so the `data cat` now shows proper characters for people (https://github.com/datahq/datahub-qa/issues/105).

data.js issue: https://github.com/datahq/data.js/issues/38

Testing:
- `data cat iso8859.csv` - you should see the proper letters