### PR TITLE
Push large files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ class FileLocal extends File {
 
   stream({end}={}) {
     // utf-8 and xls(x) files are streamed as usual file reading stream
-    if (this.descriptor.encoding === DEFAULT_ENCODING || this.path.toLowerCase().includes('xls')) {
+    if (this.descriptor.encoding === DEFAULT_ENCODING || ['xls', 'xlsx'].includes(this.descriptor.format)) {
       return fs.createReadStream(this.path, {start:0, end})
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -260,7 +260,7 @@ const parsePath = (path_, basePath = null, format = null) => {
     path: path_,
     pathType: isItUrl ? 'remote' : 'local',
     name: fileName.replace(extension, ''),
-    format: format ? format : extension.slice(1)
+    format: format ? format : extension.slice(1).toLowerCase()
   }
 
   const mediatype = mime.lookup(path_)

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,10 +119,10 @@ class FileLocal extends File {
     return this._basePath ? path.join(this._basePath, this.descriptor.path) : this.descriptor.path
   }
 
-  stream() {
+  stream({end}={}) {
     // utf-8 and xls(x) files are streamed as usual file reading stream
-    if (this.encoding === DEFAULT_ENCODING || this.path.toLowerCase().includes('xls')) {
-      return fs.createReadStream(this.path)
+    if (this.descriptor.encoding === DEFAULT_ENCODING || this.path.toLowerCase().includes('xls')) {
+      return fs.createReadStream(this.path, {start:0, end})
     }
 
     /** WARNING!! Some libs that await standard stream object could not work with iconvStreamObject.
@@ -131,8 +131,8 @@ class FileLocal extends File {
      */
 
     // non utf-8 files are decoded by iconv-lite module
-    return fs.createReadStream(this.path)
-      .pipe(iconv.decodeStream(this.encoding))
+    return fs.createReadStream(this.path, {start:0, end})
+      .pipe(iconv.decodeStream(this.descriptor.encoding))
   }
 
   get size() {

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -11,9 +11,15 @@ const csvParser = async (file, keyed = false) => {
 const guessParseOptions = async (file) => {
   const possibleDelimiters = [',', ';', ':', '|', '\t', '^', '*', '&']
   const sniffer = new CSVSniffer(possibleDelimiters)
-  const stream = await file.stream()
+  // We assume that reading first 1M bytes is enough to detect delimiter, line terminator etc.:
+  const stream = await file.stream({end: 1000000})
   const text = await toString(stream)
-  const results = sniffer.sniff(text)
+  let results
+  try {
+    results = sniffer.sniff(text)
+  } catch(err) {
+    throw err
+  }
   return {
     delimiter: results.delimiter,
     quote: results.quoteChar || '"'

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -11,9 +11,30 @@ const csvParser = async (file, keyed = false) => {
 const guessParseOptions = async (file) => {
   const possibleDelimiters = [',', ';', ':', '|', '\t', '^', '*', '&']
   const sniffer = new CSVSniffer(possibleDelimiters)
+  let text = ''
   // We assume that reading first 1M bytes is enough to detect delimiter, line terminator etc.:
-  const stream = await file.stream({end: 1000000})
-  const text = await toString(stream)
+  if (file.descriptor.pathType === 'local') {
+    const stream = await file.stream({end: 1000000})
+    text = await toString(stream)
+  } else if (file.descriptor.pathType === 'remote') {
+    const stream = await file.stream()
+    let bytes = 0
+    await new Promise((resolve, reject) => {
+      stream
+        .on('data', (chunk) => {
+          bytes += chunk.length
+          if (bytes > 1000000) {
+            stream.pause()
+            resolve()
+          } else {
+            text += chunk.toString()
+          }
+        })
+        .on('end', () => {
+          resolve()
+        })
+    })
+  }
   let results
   try {
     results = sniffer.sniff(text)

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -35,12 +35,7 @@ const guessParseOptions = async (file) => {
         })
     })
   }
-  let results
-  try {
-    results = sniffer.sniff(text)
-  } catch(err) {
-    throw err
-  }
+  const results = sniffer.sniff(text)
   return {
     delimiter: results.delimiter,
     quote: results.quoteChar || '"'

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -51,7 +51,12 @@ test('xlsxParser works with specified sheet name', async t => {
 
 test('guessParseOptions function', async t => {
   const path_ = 'test/fixtures/semicolon-delimited.csv'
-  const file = await File.load(path_)
-  const parseOptions = await guessParseOptions(file)
+  let file = await File.load(path_)
+  let parseOptions = await guessParseOptions(file)
+  t.is(parseOptions.delimiter, ';')
+
+  const url_ = 'https://raw.githubusercontent.com/frictionlessdata/test-data/master/files/csv/separators/semicolon.csv'
+  file = await File.load(url_)
+  parseOptions = await guessParseOptions(file)
   t.is(parseOptions.delimiter, ';')
 })


### PR DESCRIPTION
* Refactored `FileLocal.stream` method so it takes optional `end` argument, which is used to specify the number of the last byte that should be read. E.g., if you want to read only first 32 bytes, you'd call `file.stream({end: 32})`. This is useful when you don't need entire file stream and essential when working with large files.

* Refactored `guessParseOptions` function in CSV parser. Now we only consider first 1M bytes of files - we assume it is enough for detecting delimiter etc:
  * For local files, it is straightforward - we just pass `end` argument to `stream` method
  * For remote files, we need to calculate bytes and stop (pause) the readable stream once we have 1M bytes