### PR TITLE
fix/guessRemoteEncoding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -155,45 +155,7 @@ class FileRemote extends File {
     })()
   }
 
-  /**
-   * This getter is a sync function, and getting encoding from remote URL is
-   * an async operation, so we return DEFAULT_ENCODING for the first time,
-   * but trigger a callback that will later set:
-   *                                  this._descriptor.encoding
-   * @returns String: encoding
-   */
   get encoding() {
-
-    /*                          Temporarily Frozen.
-     This function is not recognizing  Western-MacOS-Roman encoding,
-     but works with other encodings.
-
-    const guessRemoteEncoding = async ()=>{
-      let stream
-      try {
-        stream = await this.stream()
-      } catch (err){
-        console.warn('Warning! Cannot reach remote file to guess encoding:\n', this.path)
-        return
-      }
-
-      // Download one piece of remote file on the disk and use 'chardet' lib to guess encoding:
-      stream.on('data', chunk =>{
-        stream.pause()  // one chunk is enough
-        const tmpFileName = 'tmp' + Math.random()
-        fs.writeFile(tmpFileName, chunk, ()=>{
-          let encoding = chardet.detectFileSync(tmpFileName)
-          fs.unlinkSync(tmpFileName)
-          this._descriptor.encoding = encoding   // set FileRemote object encoding
-          this._encoding = encoding  // set this._encoding for future responses
-        })
-      })
-    }
-
-    if (!this._encoding) {
-      guessRemoteEncoding()
-    }
-    */
     return this._encoding || DEFAULT_ENCODING
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,23 +164,24 @@ class FileRemote extends File {
    */
   get encoding() {
     const guessRemoteEncoding = async ()=>{
-      const stream = await this.stream()
-      new Promise((resolve, reject) => {
-        stream
-          .on('data', chunk =>{
-            stream.pause()  // one chunk is enough
+      let stream
+      try {
+        stream = await this.stream()
+      } catch (err){
+        console.warn('Warning! Cannot reach remote file to guess encoding:\n', this.path)
+        return
+      }
 
-            const tmpFile = 'encoding.tmp'
-            fs.writeFile(tmpFile, chunk, ()=>{
-              // now we have a piece of remote file on the disk.
-              let encoding = chardet.detectFileSync(tmpFile)
-              // remove tmp file
-              fs.unlinkSync(tmpFile)
-
-              this._descriptor.encoding = this._encoding = encoding
-              resolve(encoding)
-            })
-          })
+      // Download one piece of remote file on the disk and use 'chardet' lib to guess encoding:
+      stream.on('data', chunk =>{
+        stream.pause()  // one chunk is enough
+        const tmpFileName = 'tmp' + Math.random()
+        fs.writeFile(tmpFileName, chunk, ()=>{
+          let encoding = chardet.detectFileSync(tmpFileName)
+          fs.unlinkSync(tmpFileName)
+          this._descriptor.encoding = encoding   // set FileRemote object encoding
+          this._encoding = encoding  // set this._encoding for future responses
+        })
       })
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,10 +155,14 @@ class FileRemote extends File {
     })()
   }
 
+  /**
+   * This getter is a sync function, and getting encoding from remote URL is
+   * an async operation, so we return DEFAULT_ENCODING for the first time,
+   * but trigger a callback that will later set:
+   *                                  this._descriptor.encoding
+   * @returns String: encoding
+   */
   get encoding() {
-    // this is a sync function, and getting encoding from remote URL is async,
-    // so we return undefined for the first time, but trigger a callback to set
-    // this._encoding && this._descriptor.encoding   when we know the encoding.
     const guessRemoteEncoding = async ()=>{
       const stream = await this.stream()
       new Promise((resolve, reject) => {
@@ -170,9 +174,10 @@ class FileRemote extends File {
             fs.writeFile(tmpFile, chunk, ()=>{
               // now we have a piece of remote file on the disk.
               let encoding = chardet.detectFileSync(tmpFile)
+              // remove tmp file
               fs.unlinkSync(tmpFile)
-              console.log(encoding)
-              this._encoding = this._descriptor.encoding = encoding
+
+              this._descriptor.encoding = this._encoding = encoding
               resolve(encoding)
             })
           })
@@ -183,7 +188,7 @@ class FileRemote extends File {
       guessRemoteEncoding()
     }
 
-    return this._encoding //|| DEFAULT_ENCODING
+    return this._encoding || DEFAULT_ENCODING
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,34 @@ class FileRemote extends File {
   }
 
   get encoding() {
-    return DEFAULT_ENCODING
+    // this is a sync function, and getting encoding from remote URL is async,
+    // so we return undefined for the first time, but trigger a callback to set
+    // this._encoding && this._descriptor.encoding   when we know the encoding.
+    const guessRemoteEncoding = async ()=>{
+      const stream = await this.stream()
+      new Promise((resolve, reject) => {
+        stream
+          .on('data', chunk =>{
+            stream.pause()  // one chunk is enough
+
+            const tmpFile = 'encoding.tmp'
+            fs.writeFile(tmpFile, chunk, ()=>{
+              // now we have a piece of remote file on the disk.
+              let encoding = chardet.detectFileSync(tmpFile)
+              fs.unlinkSync(tmpFile)
+              console.log(encoding)
+              this._encoding = this._descriptor.encoding = encoding
+              resolve(encoding)
+            })
+          })
+      })
+    }
+
+    if (!this._encoding) {
+      guessRemoteEncoding()
+    }
+
+    return this._encoding //|| DEFAULT_ENCODING
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,11 @@ class FileRemote extends File {
    * @returns String: encoding
    */
   get encoding() {
+
+    /*                          Temporarily Frozen.
+     This function is not recognizing  Western-MacOS-Roman encoding,
+     but works with other encodings.
+
     const guessRemoteEncoding = async ()=>{
       let stream
       try {
@@ -188,7 +193,7 @@ class FileRemote extends File {
     if (!this._encoding) {
       guessRemoteEncoding()
     }
-
+    */
     return this._encoding || DEFAULT_ENCODING
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "iconv-lite": "^0.4.19",
     "lodash": "^4.17.4",
     "mime-types": "^2.1.16",
-    "node-fetch": "^1.7.2",
+    "node-fetch": "^2.0.0",
     "stream-to-array": "^2.3.0",
     "stream-to-string": "^1.1.0",
     "tableschema": "^1.6.0",

--- a/test/fixtures/encodings/iso8859.csv
+++ b/test/fixtures/encodings/iso8859.csv
@@ -1,0 +1,6 @@
+Country Name,Country Code,Year,Value
+Réunion,ECS,1989,838462813
+Réunion,ECS,1990,842848473
+Réunion,ECS,1991,846178277
+Réunion,ECS,1992,849656744
+Réunion,ECS,1993,852762014

--- a/test/fixtures/encodings/western-macos-roman.csv
+++ b/test/fixtures/encodings/western-macos-roman.csv
@@ -1,0 +1,6 @@
+Country Name,Country Code,Year,Value
+RŽunion,ECS,1989,838462813
+RŽunion,ECS,1990,842848473
+RŽunion,ECS,1991,846178277
+RŽunion,ECS,1992,849656744
+RŽunion,ECS,1993,852762014

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -214,11 +214,15 @@ const testFileStream = async (t, file) => {
   t.deepEqual(rowsAsObjects[1], {number: '3', string: 'four', boolean: 'false'})
 }
 
-test.failing('non utf-8 encoding', async t => {
+// testing the stream or the buffer for non-utf8 encoding will not work,
+// as we moved the stream decoding from the data.js lib,
+// so here we now testing if File.encoding property is correct
+test('cyrillic encoding', async t => {
   const path_ = 'test/fixtures/sample-cyrillic-encoding.csv'
   const file = await data.File.load(path_)
-  const buffer = await file.buffer
-  t.is(buffer.toString().slice(0, 12), 'номер, город')
+  //const buffer = await file.buffer
+  //t.is(buffer.toString().slice(0, 12), 'номер, город')
+  t.is(file.encoding, 'windows-1251')
 })
 
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -371,6 +371,39 @@ test('Dataset.load with url-directory', async t => {
     .persist()
     .get('/datasets/co2-ppm/master/README.md')
     .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/README.md'))
+
+  // Added mocking for all remote files in the test dataset
+  // Reason: FileRemote is now probing the remote resource to define its encoding
+  nock('https://raw.githubusercontent.com')
+    .persist()
+    .get('/datasets/co2-ppm/master/data/co2-mm-mlo.csv')
+    .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/data/co2-mm-mlo.csv'))
+
+  nock('https://raw.githubusercontent.com')
+    .persist()
+    .get('/datasets/co2-ppm/master/data/co2-annmean-mlo.csv')
+    .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/data/co2-annmean-mlo.csv'))
+
+  nock('https://raw.githubusercontent.com')
+    .persist()
+    .get('/datasets/co2-ppm/master/data/co2-gr-mlo.csv')
+    .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/data/co2-gr-mlo.csv'))
+
+  nock('https://raw.githubusercontent.com')
+    .persist()
+    .get('/datasets/co2-ppm/master/data/co2-mm-gl.csv')
+    .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/data/co2-mm-gl.csv'))
+
+  nock('https://raw.githubusercontent.com')
+    .persist()
+    .get('/datasets/co2-ppm/master/data/co2-annmean-gl.csv')
+    .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/data/co2-annmean-gl.csv'))
+
+  nock('https://raw.githubusercontent.com')
+    .persist()
+    .get('/datasets/co2-ppm/master/data/co2-gr-gl.csv')
+    .replyWithFile(200, path.join(__dirname, '/fixtures/co2-ppm/data/co2-gr-gl.csv'))
+
   const dataset = await data.Dataset.load(url)
   t.is(dataset.descriptor.name, 'co2-ppm')
   t.is(dataset.identifier.type, 'url')

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,7 +1,10 @@
 const test = require('ava')
+const nock = require('nock')
+const path = require('path')
 const toArray = require('stream-to-array')
 
 const {xlsxParser} = require('../lib/parser/xlsx')
+const {csvParser} = require('../lib/parser/csv')
 const {File} = require('../lib/index')
 const {guessParseOptions} = require('../lib/parser/csv')
 
@@ -10,6 +13,34 @@ test('xlsxParser works with XLSX files', async t => {
   const file = await File.load(path_)
   const rows = await toArray(await xlsxParser(file))
   t.deepEqual(rows[0], ['number', 'string', 'boolean'])
+})
+
+test('csvParser iso8859 file encoding', async t => {
+  const path_ = 'test/fixtures/encodings/iso8859.csv'
+  const file = await File.load(path_)
+  const rows = await toArray(await csvParser(file))
+  t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
+})
+
+test('csvParser western-macos-roman file encoding', async t => {
+  const path_ = 'test/fixtures/encodings/western-macos-roman.csv'
+  const file = await File.load(path_)
+  const rows = await toArray(await csvParser(file))
+  t.deepEqual(rows[1], ['RŽunion','ECS','1989','838462813'])
+})
+
+test('csvParser iso8859 remote file encoding', async t => {
+  const url = 'https://raw.githubusercontent.com/frictionlessdata/test-data/master/files/csv/encodings/iso8859.csv'
+  const file = await File.load(url)
+  const rows = await toArray(await csvParser(file))
+  t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
+})
+
+test('csvParser western-macos-roman remote file encoding', async t => {
+  const url = 'https://raw.githubusercontent.com/frictionlessdata/test-data/master/files/csv/encodings/western-macos-roman.csv'
+  const file = await File.load(url)
+  const rows = await toArray(await csvParser(file))
+  t.deepEqual(rows[1], ['RŽunion','ECS','1989','838462813'])
 })
 
 test('xlsxParser works with XLS files', async t => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,12 +1,9 @@
 const test = require('ava')
-const nock = require('nock')
-const path = require('path')
 const toArray = require('stream-to-array')
 
 const {xlsxParser} = require('../lib/parser/xlsx')
-const {csvParser} = require('../lib/parser/csv')
+const {csvParser, guessParseOptions} = require('../lib/parser/csv')
 const {File} = require('../lib/index')
-const {guessParseOptions} = require('../lib/parser/csv')
 
 test('xlsxParser works with XLSX files', async t => {
   const path_ = 'test/fixtures/sample.xlsx'
@@ -22,11 +19,11 @@ test('csvParser iso8859 file encoding', async t => {
   t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
 })
 
-test('csvParser western-macos-roman file encoding', async t => {
+test.failing('csvParser western-macos-roman file encoding', async t => {
   const path_ = 'test/fixtures/encodings/western-macos-roman.csv'
   const file = await File.load(path_)
   const rows = await toArray(await csvParser(file))
-  t.deepEqual(rows[1], ['RŽunion','ECS','1989','838462813'])
+  t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
 })
 
 test('csvParser iso8859 remote file encoding', async t => {
@@ -36,11 +33,11 @@ test('csvParser iso8859 remote file encoding', async t => {
   t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
 })
 
-test('csvParser western-macos-roman remote file encoding', async t => {
+test.failing('csvParser western-macos-roman remote file encoding', async t => {
   const url = 'https://raw.githubusercontent.com/frictionlessdata/test-data/master/files/csv/encodings/western-macos-roman.csv'
   const file = await File.load(url)
   const rows = await toArray(await csvParser(file))
-  t.deepEqual(rows[1], ['RŽunion','ECS','1989','838462813'])
+  t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
 })
 
 test('xlsxParser works with XLS files', async t => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -26,7 +26,8 @@ test.failing('csvParser western-macos-roman file encoding', async t => {
   t.deepEqual(rows[1], ['Réunion','ECS','1989','838462813'])
 })
 
-test('csvParser iso8859 remote file encoding', async t => {
+// this test works well, but is switched off, coz we froze remote encoding function.
+test.failing('csvParser iso8859 remote file encoding', async t => {
   const url = 'https://raw.githubusercontent.com/frictionlessdata/test-data/master/files/csv/encodings/iso8859.csv'
   const file = await File.load(url)
   const rows = await toArray(await csvParser(file))


### PR DESCRIPTION
`FileRemote.encoding` getter is updated.

- on first call method return DEFAULT_ENCODING (utf-8)
- then it runs a async function, that gets ONLY one chunk of remote file (up to ~3 kb)
- we save a piece of remote resource in a temp file
- get the file encoding via `chardet.detectFileSync()`
- delete tmp file
- set `file.descriptor.encoding`

Next time `file.encoding` returns saved encoding, without fetching remote resource.




Fix Issues:
https://github.com/datahq/datahub-qa/issues/105
https://github.com/datahq/data.js/issues/37

## Update 13 march
- Fix PR comments.
- Remove remote encoding function (not recognizing MacOS encoding)
- Encoding tests fixed for future work. 