### PR TITLE
Work in browser

### DIFF
--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -46,21 +46,40 @@ const guessParseOptions = async (file) => {
   } else if (file.descriptor.pathType === 'remote') {
     const stream = await file.stream()
     let bytes = 0
-    await new Promise((resolve, reject) => {
-      stream
-        .on('data', (chunk) => {
-          bytes += chunk.length
-          if (bytes > 1000000) {
-            stream.pause()
+    // Check if it is running on nodejs or browser:
+    if (typeof window === 'undefined') {
+      // Running on nodejs
+      await new Promise((resolve, reject) => {
+        stream
+          .on('data', (chunk) => {
+            bytes += chunk.length
+            if (bytes > 1000000) {
+              stream.pause()
+              resolve()
+            } else {
+              text += chunk.toString()
+            }
+          })
+          .on('end', () => {
             resolve()
-          } else {
-            text += chunk.toString()
-          }
-        })
-        .on('end', () => {
-          resolve()
-        })
-    })
+          })
+      })
+    } else {
+      // Running in browser:
+      // Create a transform stream with our transformer
+      const ts = new TransformStream(new Uint8ArrayToStringsTransformer())
+      // Apply our Transformer on the ReadableStream to create a stream of strings
+      const lineStream = stream.pipeThrough(ts)
+      // Read the stream of strings
+      const reader = lineStream.getReader()
+      while (Buffer.byteLength(text, 'utf8') < 1000000) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        text += value
+      }
+    }
   }
   const results = sniffer.sniff(text)
   return {

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -23,7 +23,7 @@ const csvParser = async (file, keyed = false) => {
         break
       }
       // Write each string line to our nodejs stream
-      s.push(value)
+      s.push(value + '\r\n')
     }
     s.push(null)
     stream = s
@@ -77,7 +77,7 @@ const guessParseOptions = async (file) => {
         if (done) {
           break
         }
-        text += value + '\n'
+        text += value + '\r\n'
       }
     }
   }
@@ -97,7 +97,7 @@ const getParseOptions = async (file, keyed) => {
     parseOptions.delimiter = file.descriptor.dialect.delimiter || ','
     parseOptions.rowDelimiter = file.descriptor.dialect.lineTerminator
     parseOptions.quote = file.descriptor.dialect.quoteChar || '"'
-    if (file.descriptor.dialect.doubleQuote !== undefined && dialect.doubleQuote === false) {
+    if (file.descriptor.dialect.doubleQuote !== undefined && file.descriptor.dialect.doubleQuote === false) {
       parseOptions.escape = ''
     }
   } else {

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -7,7 +7,7 @@ const iconv = require('iconv-lite')
 const csvParser = async (file, keyed = false) => {
   const parseOptions = await getParseOptions(file, keyed)
   let stream = await file.stream()
-  if (!typeof window === 'undefined') {
+  if (!(typeof window === 'undefined')) {
     // Running in browser: transform browser's ReadableStream to string, then
     // create a nodejs stream from it:
     const s = new Readable
@@ -77,7 +77,7 @@ const guessParseOptions = async (file) => {
         if (done) {
           break
         }
-        text += value
+        text += value + '\n'
       }
     }
   }
@@ -128,8 +128,6 @@ class Uint8ArrayToStringsTransformer {
    * @param {TransformStreamDefaultController} controller The controller to enqueue the transformed chunks to.
    */
   transform(chunk, controller) {
-    console.log('Received chunk %o with %d bytes.', chunk, chunk.byteLength)
-
     // Decode the current chunk to string and prepend the last string
     const string = `${this.lastString}${this.decoder.decode(chunk)}`
 

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -1,11 +1,33 @@
+const Readable = require('stream').Readable
 const parse = require('csv-parse')
-const CSVSniffer = require("csv-sniffer")()
+const CSVSniffer = require('csv-sniffer')()
 const toString = require('stream-to-string')
 const iconv = require('iconv-lite')
 
 const csvParser = async (file, keyed = false) => {
   const parseOptions = await getParseOptions(file, keyed)
-  const stream = await file.stream()
+  let stream = await file.stream()
+  if (!typeof window === 'undefined') {
+    // Running in browser: transform browser's ReadableStream to string, then
+    // create a nodejs stream from it:
+    const s = new Readable
+    // Create a transform stream with our transformer
+    const ts = new TransformStream(new Uint8ArrayToStringsTransformer())
+    // Apply our Transformer on the ReadableStream to create a stream of strings
+    const lineStream = stream.pipeThrough(ts)
+    // Read the stream of strings
+    const reader = lineStream.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      // Write each string line to our nodejs stream
+      s.push(value)
+    }
+    s.push(null)
+    stream = s
+  }
   if (file.descriptor.encoding.toLowerCase().replace('-', '') === 'utf8') {
     return stream.pipe(parse(parseOptions))
   } else { // non utf-8 files are decoded by iconv-lite module
@@ -67,6 +89,56 @@ const getParseOptions = async (file, keyed) => {
 
   return parseOptions
 }
+
+/**
+ * This transformer takes binary Uint8Array chunks from a `fetch`
+ * and translates them to chunks of strings.
+ *
+ * @implements {TransformStreamTransformer}
+ */
+class Uint8ArrayToStringsTransformer {
+  constructor() {
+    this.decoder = new TextDecoder()
+    this.lastString = ''
+  }
+
+  /**
+   * Receives the next Uint8Array chunk from `fetch` and transforms it.
+   *
+   * @param {Uint8Array} chunk The next binary data chunk.
+   * @param {TransformStreamDefaultController} controller The controller to enqueue the transformed chunks to.
+   */
+  transform(chunk, controller) {
+    console.log('Received chunk %o with %d bytes.', chunk, chunk.byteLength)
+
+    // Decode the current chunk to string and prepend the last string
+    const string = `${this.lastString}${this.decoder.decode(chunk)}`
+
+    // Extract lines from chunk
+    const lines = string.split(/\r\n|[\r\n]/g)
+
+    // Save last line, as it might be incomplete
+    this.lastString = lines.pop() || ''
+
+    // Enqueue each line in the next chunk
+    for (const line of lines) {
+      controller.enqueue(line)
+    }
+  }
+
+  /**
+   * Is called when `fetch` has finished writing to this transform stream.
+   *
+   * @param {TransformStreamDefaultController} controller The controller to enqueue the transformed chunks to.
+   */
+  flush(controller) {
+    // Is there still a line left? Enqueue it
+    if (this.lastString) {
+      controller.enqueue(this.lastString)
+    }
+  }
+}
+
 
 module.exports = {
   csvParser,

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,9 +772,9 @@ chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chardet@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.1.0.tgz#e266612d5b78262e998663ef17d06eb7a1b7b8c2"
+chardet@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 chokidar@^1.4.2:
   version "1.7.0"
@@ -1186,12 +1186,6 @@ empower-core@^0.6.1:
   dependencies:
     call-signature "0.0.2"
     core-js "^2.0.0"
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
 
 enhance-visitors@^1.0.0:
   version "1.0.0"
@@ -1876,9 +1870,11 @@ hullabaloo-config-manager@^1.1.0:
     resolve-from "^3.0.0"
     safe-buffer "^5.0.1"
 
-iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+iconv-lite@^0.4.19:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ignore-by-default@^1.0.0:
   version "1.0.1"
@@ -2157,7 +2153,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2503,9 +2499,9 @@ minimist@^1.1.3, minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-moment@~2.18.0:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@~2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 ms@2.0.0, ms@^2.0.0:
   version "2.0.0"
@@ -2546,12 +2542,9 @@ nock@^9.0.14:
     qs "^6.5.1"
     semver "^5.3.0"
 
-node-fetch@^1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
+node-fetch@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -3183,6 +3176,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -3431,16 +3428,17 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-tableschema@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/tableschema/-/tableschema-1.6.0.tgz#2ddf30b537b63856d27f315e3dd80abd71f365ea"
+tableschema@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tableschema/-/tableschema-1.9.1.tgz#4814e1b6ca7b81b94dc8e5d7ea197e3d84c212f3"
   dependencies:
     axios "^0.17.1"
     csv "^1.1.1"
+    csv-sniffer "^0.1.1"
     d3-time-format "^0.3.2"
     es6-error "^4.0.2"
     lodash "^4.13.1"
-    moment "~2.18.0"
+    moment "~2.21.0"
     regenerator-runtime "^0.11.0"
     stream-to-async-iterator "^0.2.0"
     tv4 "^1.2.7"


### PR DESCRIPTION
In browsers, 'fetch' returns Readable Stream that has different API than nodejs streams. This caused problems when using 'data.js' in browsers so we've decided to convert browser's Readable Stream into nodejs like streams to make it work.

* fix for `csvParser` function
* fix for `guessParseOptions` function

Links:

* Readable Streams https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream

Notes:

* Using browserify or webpack didn't help to solve the problem.
* Replacing 'fetch' with 'axios' didn't help to solve the problem.