### PR TITLE
Fix: In rows() function use size as a number of rows

### DIFF
--- a/browser-test/index.spec.js
+++ b/browser-test/index.spec.js
@@ -36,16 +36,20 @@ describe('FileInterface', function () {
   })
 
   it('rows()', async () => {
-    debugger
     const file = new data.open(genFile())
 
-    const rowStream = await file.rows({ size: -1 })
-    const rows = await toArray(rowStream)
+    let rowStream = await file.rows({ size: -1 })
+    let rows = await toArray(rowStream)
     expect(rows[0]).toEqual(['number', 'string', 'boolean'])
     expect(rows[1]).toEqual(['1', 'two', 'true'])
+
+    rowStream = await file.rows({ size: 1 })
+    rows = await toArray(rowStream)
+    expect(rows[0]).toEqual(['number', 'string', 'boolean'])
+    expect(rows[1]).toEqual(undefined)
   })
 
-  it('rows()', async () => {
+  it('stream()', async () => {
     debugger
     const file = new data.open(genFile())
 

--- a/src/index.js
+++ b/src/index.js
@@ -156,10 +156,7 @@ class FileInterface extends File {
    */
   stream({ size } = {}) {
     size = size === -1 ? this.size : size || 0
-    return browser.toNodeStream(
-      this.descriptor.slice(0, size).stream().getReader(),
-      size
-    )
+    return browser.toNodeStream(this.descriptor.stream().getReader(), size)
   }
 
   buffer(size) {


### PR DESCRIPTION
Also added test to check the rows in case of `size` other than `-1`