### PR TITLE
Fix for failing tests due to buffer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const stream = await file.stream()
 const rows = await resource.rows()
 
 // entire file as a buffer (be careful with large files!)
-const buffer = await resource.buffer()
+const buffer = await resource.buffer
 ```
 
 With a Dataset:
@@ -272,7 +272,7 @@ Get readable stream
 
 #### buffer
 
-`File.buffer()`
+`File.buffer`
 
 Get this file as a buffer (async)
 

--- a/browser-test/index.spec.js
+++ b/browser-test/index.spec.js
@@ -59,7 +59,7 @@ describe('FileInterface', function () {
     expect(out.toString().indexOf('number,string,boolean')).toBeGreaterThan(-1)
 
     // Test buffer
-    const buffer = await file.buffer(-1)
+    const buffer = await file.buffer
     const text = new TextDecoder('utf-8').decode(buffer)
     expect(text.slice(0, 21)).toBe('number,string,boolean')
   })


### PR DESCRIPTION
Fixes #81 

As per original implementation, `buffer` method should be a getter method so we don't need to 'call' it. That was fixed previously in https://github.com/datopian/data.js/commit/1f872304476ee14c8df533bf0278f3c9431710f5 but the tests weren't updated. This PR delivers tests and README updates.