### PR TITLE
Allow computeHash to take the encoding as parameter

### DIFF
--- a/test/file-base.js
+++ b/test/file-base.js
@@ -105,6 +105,18 @@ describe('computeHash', () => {
     )
     assert.strictEqual(hashmd5, '37d3a5159433f0977afb03d01d4bde6e')
   })
+
+  it('encodes the hash using base64', async () => {
+    const path_ = 'test/fixtures/sample-cyrillic-encoding.csv'
+    const file = data.open(path_)
+
+    let hash256 = await computeHash(file.stream(), file.size, 'sha256', null, 'base64')
+
+    assert.strictEqual(
+      hash256,
+      'jv9aeBWGRhUwnUgDW0Ybeaob3EQCkk6X/GbhI3JSFP0='
+    )
+  })
 })
 
 describe('hashSha256', () => {


### PR DESCRIPTION
I need to have the hash in base64 encoding in my code. This change enables specifying a few different values for the digest encoding:
* hex (default)
* base64
* latin1 or binary which are equivalent 

The default behavior should not be affected; This should be backwards compatible. 